### PR TITLE
Remove run_once when download restic binary

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,6 @@
   get_url:
     url: "https://github.com/restic/restic/releases/download/v{{ restic_version }}/restic_{{ restic_version }}_{{ ansible_system | lower }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2"  # noqa 204
     dest: "/tmp/restic_{{ restic_version }}_{{ ansible_system | lower }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2"  # noqa 204
-  run_once: true
 
 - name: decompress restic binary
   shell: "bzip2 -dc /tmp/restic_{{ restic_version }}_{{ ansible_system | lower }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}.bz2 > /tmp/restic_{{ restic_version }}_{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}"  # noqa 204


### PR DESCRIPTION
The task is executed only on the first host when the roles runs in multiple hosts.
Removing run_once should fix this issue.

```
TASK [hadret.restic : ensure restic installation directory exist] ***********************************************************
ok: [vm1.local]
ok: [vm2.local]

TASK [hadret.restic : download restic binary] *******************************************************************************
ok: [vm1.local]

TASK [hadret.restic : decompress restic binary] *****************************************************************************
ok: [vm1.local]
fatal: [vm2.local]: FAILED! => {"changed": true, "cmd": "bzip2 -dc /tmp/restic_0.9.5_linux_amd64.bz2 > /tmp/restic_0.9.5_amd64", "delta": "0:00:00.008050", "end": "2019-10-23 10:45:41.240274", "msg": "non-zero return code", "rc": 1, "start": "2019-10-23 10:45:41.232224", "stderr": "bzip2: Can't open input file /tmp/restic_0.9.5_linux_amd64.bz2: No such file or directory.", "stderr_lines": ["bzip2: Can't open input file /tmp/restic_0.9.5_linux_amd64.bz2: No such file or directory."], "stdout": "", "stdout_lines": []}

TASK [hadret.restic : copy restic binary] ***********************************************************************************
ok: [vm1.local]
```