### PR TITLE
Prometheus monitoring integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 ---
 language: python
+python:
+  - "3.9"
 services: docker
+dist: focal
 
 env:
   matrix:
@@ -9,7 +12,7 @@ env:
     - MOLECULE_DISTRO: debian11
 
 install:
-  - pip install molecule yamllint ansible-lint docker
+  - pip install ansible docker molecule-docker
 
 script:
   - molecule test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   matrix:
     - MOLECULE_DISTRO: ubuntu2004
     - MOLECULE_DISTRO: ubuntu1804
+    - MOLECULE_DISTRO: debian11
 
 install:
   - pip install molecule yamllint ansible-lint docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ env:
   matrix:
     - MOLECULE_DISTRO: ubuntu2004
     - MOLECULE_DISTRO: ubuntu1804
-    - MOLECULE_DISTRO: ubuntu1604
-    - MOLECULE_DISTRO: debian10
 
 install:
   - pip install molecule yamllint ansible-lint docker

--- a/.yamllint
+++ b/.yamllint
@@ -1,8 +1,0 @@
----
-extends: default
-ignore:
-  virtenv/
-rules:
-  line-length:
-    max: 300
-    level: warning

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Available variables are listed below, along with default values (see
 [defaults/main.yml](defaults/main.yml)):
 
 ```
-restic_version: '0.12.0'
+restic_version: '0.12.1'
 restic_install_path: '/usr/local/bin'
 restic_password_file_path: '/root'
 restic_discard_cron_stdout: false
@@ -50,6 +50,16 @@ Defines whether the cronjob output should be directed to `/dev/null` or not
 (it will send e-mail on each execution if this is set to `false`).
 
 ```
+restic_prometheus_exporter: true
+restic_prometheus_output_path: /var/lib/node_exporter/textfile_collector
+```
+
+It enables very simple Prometheus integration that is going to write three
+values to the default textfile collector location. Please note that enabling
+support for this is going to install/require two additional dependencies:
+`jq` and `moreutils` (for `sponge`).
+
+```
 restic_repos: []
 ```
 
@@ -78,7 +88,8 @@ This role builds on the shoulders of
 [donat-b/ansible-restic](https://github.com/donat-b/ansible-restic) and
 [paulfantom/ansible-restic](https://github.com/paulfantom/ansible-restic). All
 of the `molecule` tests and CI configuration are based on work of
-[geerlingguy](https://github.com/geerlingguy).
+[geerlingguy](https://github.com/geerlingguy). A lot of parts for the Prometheus integration had been taken
+directly from [this Restic forum thread](https://forum.restic.net/t/restic-grafana-dashboard/1662/6).
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@ restic_install_path: '/usr/local/bin'
 restic_password_file_path: '/root'
 restic_discard_cron_stdout: false
 
+# restic_prometheus_exporter: false
+# restic_prometheus_output_path: /var/lib/node_exporter/textfile_collector
+
 restic_repos: []
 # restic_repos:
 # - name: s3-example

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,8 @@ restic_password_file_path: '/root'
 restic_discard_cron_stdout: false
 
 # restic_prometheus_exporter: false
-# restic_prometheus_output_path: /var/lib/node_exporter/textfile_collector
+# restic_prometheus_output_path: '/var/lib/node_exporter/textfile_collector'
+# restic_prometheus_time: '0 0 * * *'
 
 restic_repos: []
 # restic_repos:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,6 +2,7 @@
 - name: test all the things
   hosts: all
   become: true
-
+  pre_tasks:
+    - apt: update_cache=yes
   roles:
     - role: ansible-role-restic

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,17 +5,13 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1804}-ansible
+    image: 'geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest'
     command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
 provisioner:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
-scenario:
-  name: default
-lint: |
-  set -e
-  yamllint .
-  ansible-lint

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,14 @@
     name: '{{ restic_dependencies | default([]) }}'
     state: present
 
+- name: install dependencies for prometheus integration
+  package:
+    name:
+      - jq
+      - moreutils
+    state: present
+  when: restic_prometheus_exporter | default("false") | bool
+
 # TODO: provide installation method from official repositories
 - name: download restic binary
   get_url:
@@ -98,3 +106,15 @@
   with_items: "{{ restic_repos }}"
   no_log: "{{ restic_ansible_nolog|default(item.no_log | default(true)) }}"
   become: true
+
+- name: deploy prometheus exporter script
+  template:
+    src: "restic-exporter.sh.j2"
+    dest: "{{ restic_install_path }}/restic-{{ item.name }}-exporter"
+    mode: "0770"
+    owner: "root"
+    group: "{{ restic_group }}"
+  with_items: "{{ restic_repos }}"
+  no_log: "{{ restic_ansible_nolog|default(item.no_log | default(true)) }}"
+  become: true
+  when: restic_prometheus_exporter | default("false") | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,6 +74,9 @@
     state: present
   when: ansible_system == "Linux"
   become: true
+  # Disabled due to this bug: https://github.com/ansible/ansible/issues/47156
+  tags:
+    - molecule-idempotence-notest
 
 - name: deploy password files
   lineinfile:

--- a/templates/restic-exporter.sh.j2
+++ b/templates/restic-exporter.sh.j2
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+# {{ ansible_managed }}
+
+{{ restic_install_path }}/restic-{{ item.name | trim | quote }} stats latest --json | /usr/bin/jq -r '"restic_stats_total_size_bytes \(.total_size)\nrestic_stats_total_file_count \(.total_file_count)"' | /usr/bin/sponge {{ restic_prometheus_output_path | default('/var/lib/node_exporter/textfile_collector') }}/restic-{{ item.name | trim | quote }}.prom
+{{ restic_install_path }}/restic-{{ item.name | trim | quote }} snapshots latest --json | /usr/bin/jq -r 'max_by(.time) | .time | sub("[.][0-9]+"; "") | sub("Z"; "+00:00") | def parseDate(date): date | capture("(?<no_tz>.*)(?<tz_sgn>[-+])(?<tz_hr>\\d{2}):(?<tz_min>\\d{2})$") | (.no_tz + "Z" | fromdateiso8601) - (.tz_sgn + "60" | tonumber) * ((.tz_hr | tonumber) * 60 + (.tz_min | tonumber)); parseDate(.) | "restic_last_snapshot_timestamp \(.)"' | /usr/bin/sponge -a {{ restic_prometheus_output_path | default('/var/lib/node_exporter/textfile_collector') }}/restic-{{ item.name | trim | quote }}.prom

--- a/templates/restic.cron.j2
+++ b/templates/restic.cron.j2
@@ -21,6 +21,12 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:{{ restic_inst
 {{ item.check_time | default('17 4 * * *') }} {{ restic_user }} restic-{{ item.name }} check{% if restic_discard_cron_stdout %} > /dev/null{% endif %}
 {%- endif %}
 
+{% if restic_prometheus_exporter | default(false) -%}
+# Dump stats for Prometheus
+{{ restic_prometheus_time | default('0 0 * * *') }} {{ restic_user }} restic-{{ item.name }}-exporter{% if restic_discard_cron_stdout %} > /dev/null{% endif %}
+
+{% endif -%}
+
 # Do an actual backup
 {% for job in item.jobs %}
 {{ job.at }} {{ restic_user }} {{ job.command }}{% if restic_discard_cron_stdout %} > /dev/null{% endif %}


### PR DESCRIPTION
This PR introduces support for writing down statistics for Prometheus integration. `node_exporter` is required in order to pick up these values for scraping. By default the prom file(s) are going to be written to the `/var/lib/node_exporter/textfile_collector` which is the default location to textfile collector.