### PR TITLE
added restic_options under restic_repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Available variables are listed below, along with default values (see
 [defaults/main.yml](defaults/main.yml)):
 
 ```
-restic_version: '0.15.1'
+restic_version: '0.17.3'
 restic_install_path: '/usr/local/bin'
 restic_password_file_path: '/root'
 restic_discard_cron_stdout: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-restic_version: '0.15.1'
+restic_version: '0.17.3'
 restic_install_path: '/usr/local/bin'
 restic_password_file_path: '/root'
 restic_discard_cron_stdout: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,6 +21,7 @@ galaxy_info:
         - bionic
         - focal
         - jammy
+        - noble
     - name: FreeBSD
       versions:
         - 12.3

--- a/templates/restic-wrapper.sh.j2
+++ b/templates/restic-wrapper.sh.j2
@@ -9,4 +9,4 @@ export {{ k | upper }}={{ v | trim | quote }}
 {% endfor %}
 {% endif %}
 
-"{{ restic_install_path }}/restic" {% if item.legacy_list_objects is defined %}-o s3.list-objects-v1={{ item.legacy_list_objects }} {% endif %}"$@"
+"{{ restic_install_path }}/restic" {% if item.restic_options is defined %}-o {{ item.restic_options  }} {% endif %} {% if item.legacy_list_objects is defined %}-o s3.list-objects-v1={{ item.legacy_list_objects }} {% endif %}"$@"


### PR DESCRIPTION
Dear Filip,

please consider the pull request, which adds `restic_options` to `restic_repos`. And updates to the latest restic binary, but that's a trivial change.

I needed this functionality to add ssh options to restic to be able to use scp with the [Hetzner StorageBox](https://www.hetzner.com/storage/storage-box/).

Thanks

 Torsten
